### PR TITLE
Fix red pajama bug

### DIFF
--- a/examples/redpajama-incite-instruct/redpajama-incite-instruct-3b-v1.py
+++ b/examples/redpajama-incite-instruct/redpajama-incite-instruct-3b-v1.py
@@ -30,9 +30,8 @@ def run(**inputs):
     # Generate output
     input = tokenizer(prompt, return_tensors="pt").to(model.device)
     input_length = input.input_ids.shape[1]
-    inputs.pop("prompt")
     outputs = model.generate(
-        **inputs,
+        **input,
         max_new_tokens=128,
         do_sample=True,
         temperature=0.7,


### PR DESCRIPTION
I was getting garbage out of red pajama, so I took a closer look at the code.

The problem was that the "inputs" variable (which contains the prompt) is incorrectly used to call `model.generate()`. The right thing to do is to use the array received from the `tokenizer()`

With this change, now red pajama works as expected.